### PR TITLE
Pairing guide updates

### DIFF
--- a/pairing_file.md
+++ b/pairing_file.md
@@ -14,7 +14,7 @@ iDevicePair allows us to create a pairing file for programs like StikDebug to ta
 2. Download `iDevicePair--windows-x86_64.exe` (move it somewhere you won't lose it).
 3. Connect your secondary device to your computer via cable. If a prompt appears, tap "trust" and type in your passcode.
 4. Unlock your device, open iDevicePair, and select your device in the drop-down menu.
-5. Ensure your device is unlocked and opened to the home screen, then select "generate". When a prompt appears on your device, tap "trust". Your pairing file should appear.
+5. Ensure your device is unlocked and opened to the home screen, then select "generate" (If you are using an app such as SideStore which also utilizes a pairing file, select "load" instead). When a prompt appears on your device, tap "trust". Your pairing file should appear.
 6. Ensure your device is still open to the home screen, then scroll down to the StikDebug section and select "install". The word "success" should appear in green.
 
 ### macOS
@@ -22,7 +22,7 @@ iDevicePair allows us to create a pairing file for programs like StikDebug to ta
 1. Download `iDevicePair--macos-universal.dmg`. Open the file and drag "iDevicePair" to your Applications folder.
 3. Connect your secondary device to your computer via cable. If a prompt appears, tap "trust" and type in your passcode.
 4. Unlock your device, open iDevicePair, and select your device in the drop-down menu.
-5. Ensure your device is unlocked and opened to the home screen, then select "generate". When a prompt appears on your device, tap "trust". Your pairing file should appear.
+5. Ensure your device is unlocked and opened to the home screen, then select "generate" (If you are using an app such as SideStore which also utilizes a pairing file, select "load" instead). When a prompt appears on your device, tap "trust". Your pairing file should appear.
 6. Ensure your device is still open to the home screen, then scroll down to the StikDebug section and select "install". The word "success" should appear in green.
 
 ### Linux

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -6,7 +6,7 @@
 - **Linux**: (x86_64: [iDevicePair--linux-x86_64.AppImage](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-x86_64.AppImage), aarch64: [iDevicePair--linux-aarch64.AppImage](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-aarch64.AppImage))
 ---
 
-iDevicePair allows us to create a pairing file for programs like StikDebug to talk to your device remotely. This is required to use StikDebug, otherwise it would not function..
+iDevicePair allows us to create a pairing file for programs like StikDebug to talk to your device remotely. This is required to use StikDebug, otherwise it will not function.
 
 ### Windows
 

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -46,4 +46,4 @@ These instructions expect that you are familiar with the linux commandline.
    ```
 7. The first time you execute the tool, you will get a prompt for your passcode on your secondary device. Type it in, then keep the screen on and unlocked and run the tool again. Type it in, then keep the screen on and unlocked and execute the tool again.
 8. JitterbugPair will generate a **pairing file** with the extension `.mobiledevicepairing`.
-9. Compress the file into a .zip folder. Then, **transfer the pairing file** to your iOS device using email, cloud storage, or another method you prefer.
+9. Compress the file into a .zip folder. Then, **transfer the pairing file** to your iOS device using email, cloud storage, or another method you prefer. On your iOS/iPadOS device's Files app, long press on the file, then select "Uncompress". Inside StikDebug, select "Choose Pairing File", then select your unzipped pairing file.

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -6,44 +6,38 @@
 - **Linux**: (x86_64: [iDevicePair--linux-x86_64.AppImage](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-x86_64.AppImage) or AArch64: [iDevicePair--linux-aarch64.AppImage](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-aarch64.AppImage))
 ---
 
-iDevice Pair allows us to create a pairing file for programs like StikDebug to talk to your device remotely. This is required to use StikDebug, otherwise it will not function.
+idevice pair allows us to create a pairing file for programs like StikDebug to talk to your device remotely. This is required to use StikDebug, otherwise it will not function.
 
-### Windows
+## Pairing Instructions
 
-1. Install iTunes from Apple's website ([64-bit](https://apple.com/itunes/download/win64) or [32-bit](https://apple.com/itunes/download/win32)).
+### Windows (64-bit)
+
+1. Install [iTunes](https://apple.com/itunes/download/win64) from Apple's website.
 2. Download `iDevicePair--windows-x86_64.exe` (move it somewhere you won't lose it).
 3. Connect your secondary device to your computer via cable. If a prompt appears, tap "trust" and type in your passcode.
-4. Unlock your device, open iDevice Pair, and select your device in the drop-down menu.
-5. Ensure your device is unlocked and opened to the home screen, then select "generate" (If also use an app such as SideStore which utilizes this pairing file, select "load" instead). When a prompt appears on your device, tap "trust". Your pairing file should appear.
+4. Unlock your device, then, in File Explorer, open `idevice pair` and select your device in the drop-down menu.
+5. Ensure your device is unlocked and opened to the home screen, then select "generate" (If also using an app such as SideStore or Feather which utilizes a pairing file as well, select "load" instead). When a prompt appears on your device, tap "trust". Your pairing file should appear.
 6. Ensure your device is still open to the home screen, then scroll down to the StikDebug section and select "install". The word "success" should appear in green.
-
+also
 ### macOS
 
-1. Download `iDevicePair--macos-universal.dmg`. Open the file and drag `iDevice Pair` to your Applications folder.
-3. Connect your secondary device to your computer via cable. If a prompt appears, tap "trust" and type in your passcode.
-4. Unlock your device, open iDevice Pair, and select your device in the drop-down menu.
-5. Ensure your device is unlocked and opened to the home screen, then select "generate" (If you also use an app such as SideStore which also utilizes this pairing file, select "load" instead). When a prompt appears on your device, tap "trust". Your pairing file should appear.
-6. Ensure your device is still open to the home screen, then scroll down to the StikDebug section and select "install". The word "success" should appear in green.
+1. Download `iDevicePair--macos-universal.dmg`. Open the file and drag `idevice pair` to `Applications`.
+2. Connect your secondary device to your computer via cable. If a prompt appears, tap "trust" and type in your passcode.
+3. Unlock your device, then open idevice pair and select your device in the drop-down menu.
+4. Ensure your device is unlocked and opened to the home screen, then select "generate" (If also using an app such as SideStore or Feather which utilizes a pairing file as well, select "load" instead). When a prompt appears on your device, tap "trust". Your pairing file should appear.
+5. Ensure your device is still open to the home screen, then scroll down to the StikDebug section and select "install". The word "success" should appear in green.
 
 ### Linux
 
-> [!TIP]
-> The iDevice Pair instructions for Linux are a work-in-progress, though iDevice Pair is pretty intuitive if you want to give it a try without docs first. For now, instructions to create a pairing file using JitterbugPair for Linux are below!
-
 These instructions expect that you are familiar with the linux commandline.
 
-1. **Download** `jitterbugpair-linux.zip` from [here](https://github.com/osy/Jitterbug/releases/download/v1.3.1/jitterbugpair-linux.zip), then extract it.
-2. Open a terminal in the extracted directory.
-3. Make the program executable:
-   ```bash
-   chmod +x ./jitterbugpair
-   ```
-4. **Set a passcode** for your device if you haven't already. Unlock your device and connect it to your computer via cable. If a prompt appears, tap "trust" and type in your passcode.
-5. Open your device to the homescreen.
-6. Execute the program:
-   ```bash
-   ./jitterbugpair
-   ```
-7. The first time you execute the tool, you will get a prompt for your passcode on your secondary device. Type it in, then keep the screen on and unlocked and run the tool again. Type it in, then keep the screen on and unlocked and execute the tool again.
-8. JitterbugPair will generate a **pairing file** with the extension `.mobiledevicepairing`.
-9. Compress the file into a .zip folder. Then, **transfer the pairing file** to your iOS device using email, cloud storage, or another method you prefer. On your iOS/iPadOS device's Files app, long press on the file, then select "Uncompress". Inside StikDebug, select "Choose Pairing File", then select your unzipped pairing file.
+1. In the linux commandline, run the following code:
+```
+sudo apt update
+sudo apt install usbmuxd
+```
+2. Download the version of idevice pair that corresponds to your PC's architecture and make it executable.
+3. Connect your secondary device to your computer via cable. If a prompt appears, tap "trust" and type in your passcode.
+4. Unlock your device, then execute idevice pair and select your device in the drop-down menu.
+5. Ensure your device is unlocked and opened to the home screen, then select "generate" (If also using an app such as SideStore or Feather which utilizes a pairing file as well, select "load" instead). When a prompt appears on your device, tap "trust". Your pairing file should appear.
+6. Ensure your device is still open to the home screen, then scroll down to the StikDebug section and select "install". The word "success" should appear in green.

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -1,69 +1,52 @@
 ## Pairing Instructions
 
 ### Downloads
-- **Windows**: [jitterbugpair-win64.zip](https://github.com/osy/Jitterbug/releases/download/v1.3.1/jitterbugpair-win64.zip)
-- **macOS**: [jitterbugpair](https://github.com/SideStore/SideStore-Docs/releases/download/need-a-place-to-put-jittterbug/jitterbugpair)
+- **Windows**: [iDevicePair--windows-x86_64.exe](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--windows-x86_64.exe)
+- **macOS**: [iDevicePair--macos-universal.dmg](github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--macos-universal.dmg)
 - **Linux**: [jitterbugpair-linux.zip](https://github.com/osy/Jitterbug/releases/download/v1.3.1/jitterbugpair-linux.zip)
 
 ---
 
+iDevicePair allows us to create a pairing file for programs like SideStore to talk to your device remotely. This is required to use SideStore, or it will not function.
+
+Download iDevicePair for Linux ([x86_64](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-x86_64.AppImage) or [aarch64](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-aarch64.AppImage)).
+
+### Windows
+
+1. Install iTunes from Apple's website ([64-bit](https://apple.com/itunes/download/win64) or [32-bit](https://apple.com/itunes/download/win32)).
+2. Download `iDevicePair--windows-x86_64.exe` (move it somewhere you won't lose it).
+3. Connect your secondary device to your computer via cable. If a prompt appears, tap "trust" and type in your passcode.
+4. Unlock your device, open iDevicePair, and select your device in the drop-down menu.
+5. Ensure your device is unlocked and opened to the home screen, then select "generate". When a prompt appears on your device, tap "trust". Your pairing file should appear.
+6. Ensure your device is still open to the home screen, then scroll down to the SideStore section and select "install". The word "success" should appear in green.
+
+### macOS
+
+1. Download `iDevicePair--macos-universal.dmg`. Open the file and drag "iDevicePair" to your Applications folder.
+3. Connect your secondary device to your computer via cable. If a prompt appears, tap "trust" and type in your passcode.
+4. Unlock your device, open iDevicePair, and select your device in the drop-down menu.
+5. Ensure your device is unlocked and opened to the home screen, then select "generate". When a prompt appears on your device, tap "trust". Your pairing file should appear.
+6. Ensure your device is still open to the home screen, then scroll down to the SideStore section and select "install". The word "success" should appear in green.
+
+### Linux
+
 > [!TIP]
-> When using cloud storage, the file extension might change (usually to .txt). It is always recommended to zip your pairing file before transferring it. StikDebug only accepts `.mobiledevicepairing` or `.plist` files.
+> The iDevicePair instructions for Linux are a work-in-progress. For now, instructions to create a pairing file using JitterbugPair for Linux are below!
 
+These instructions expect that you are familiar with the linux commandline.
 
-### For Windows
-
-1. **Extract** `jitterbugpair-win64.zip`.
-2. **Set a passcode** for your device if you haven't already. Unlock your device and connect it to your computer via cable. When a prompt appears, tap "Trust."
-3. Open your device to the homescreen.
-4. In File Explorer, locate `jitterbugpair.exe` and run it by double-clicking or right-clicking and selecting "Open".
-5. JitterbugPair will generate a **pairing file** in the same folder. This file will have the extension `.mobiledevicepairing`.
-6. **Transfer the pairing file** to your iOS device using One/iCloud/Google Drive, email, or any other method. For best results, compress the file into a .zip folder first.
-
----
-
-### For macOS
-
-1. **Extract** `Jitterbugpair-macos.zip` (if applicable).
-2. **Set a passcode** for your device if you haven't already. Unlock your device and connect it to your computer via cable. When a prompt appears, tap "Trust."
-3. Open your device to the homescreen.
-4. Find and open the extracted `jitterbugpair` file (it should have a black and green icon) by double-clicking it or right-clicking it and selecting "Open."
-5. If you get the message" "macOS cannot verify that this app is free from malware":
-   - Go to System Settings > Privacy & Security
-   - Scroll down to the message about the app
-   - Click "Open Anyway," if the program doesn't run automatically, try manually running it again
-7. JitterbugPair will generate a **pairing file** with the extension `.mobiledevicepairing` to your user's home folder.
-8. If you can't find the pairing file:
-   - Copy the name of the pairing file generated
-   - Paste it into Finder
-   - If you ran the program more than once, all pairing files for your device should appear since they share the same name
-9. **Transfer the pairing file** to your iOS device using AirDrop, iCloud/One/Google Drive, email, or any other method. For best results, compress the file into a .zip folder first.
-
----
-
-### For Linux
-
-1. **Extract** `jitterbugpair-linux.zip`.
+1. **Download** `jitterbugpair-linux.zip` from [here](https://github.com/osy/Jitterbug/releases/download/v1.3.1/jitterbugpair-linux.zip), then extract it.
 2. Open a terminal in the extracted directory.
 3. Make the program executable:
    ```bash
    chmod +x ./jitterbugpair
    ```
-4. **Set a passcode** for your device if you haven't already. Unlock your device and connect it to your computer via cable. When a prompt appears, tap "Trust."
+4. **Set a passcode** for your device if you haven't already. Unlock your device and connect it to your computer via cable. If a prompt appears, tap "trust" and type in your passcode.
 5. Open your device to the homescreen.
 6. Execute the program:
    ```bash
    ./jitterbugpair
    ```
-7. JitterbugPair will generate a **pairing file** with the extension `.mobiledevicepairing`.
-8. **Transfer the pairing file** to your iOS device using your preferred method. For best results, compress the file into a .zip folder first.
-
----
-
-### On your iOS device
-
-1. In the **Files app**, locate your newly-generated pairing file. (If zipped, long-press your zipped pairing file and select **Uncompress**.)
-2. Launch the **StikDebug** app.
-   - If the app doesn't appear, restart your device.
-3. Upon launching the app, tap **Import Pairing File**, then navigate to and select your **unzipped pairing file**.
-4. StikDebug is now ready for use.
+7. The first time you execute the tool, you will get a prompt for your passcode on your secondary device. Type it in, then keep the screen on and unlocked and run the tool again. Type it in, then keep the screen on and unlocked and execute the tool again.
+8. JitterbugPair will generate a **pairing file** with the extension `.mobiledevicepairing`.
+9. Compress the file into a .zip folder. Then, **transfer the pairing file** to your iOS device using email, cloud storage, or another method you prefer.

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -2,7 +2,7 @@
 
 ### Downloads
 - **Windows**: [jitterbugpair-win64.zip](https://github.com/osy/Jitterbug/releases/download/v1.3.1/jitterbugpair-win64.zip)
-- **macOS**: [jitterbugpair-macos.zip](https://github.com/osy/Jitterbug/releases/download/v1.3.1/jitterbugpair-macos.zip)
+- **macOS**: [jitterbugpair](https://github.com/SideStore/SideStore-Docs/releases/download/need-a-place-to-put-jittterbug/jitterbugpair)
 - **Linux**: [jitterbugpair-linux.zip](https://github.com/osy/Jitterbug/releases/download/v1.3.1/jitterbugpair-linux.zip)
 
 ---
@@ -20,7 +20,7 @@
 
 ### For macOS
 
-1. **Extract** `Jitterbugpair-macos.zip`.
+1. **Extract** `Jitterbugpair-macos.zip` (if applicable).
 2. **Set a passcode** for your device if you haven't already. Unlock your device and connect it to your computer via cable. When a prompt appears: tap "Trust."
 3. Open your device to the homescreen.
 4. Find the extracted `jitterbugpair` file (it should have a black and green icon).

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -21,7 +21,7 @@
 ### For macOS
 
 1. **Extract** `Jitterbugpair-macos.zip`.
-2. **Set a passcode** for your device if you haven't already. Unlock your device, connect it to your computer via cable. If a prompt appears: tap "Trust."
+2. **Set a passcode** for your device if you haven't already. Unlock your device and connect it to your computer via cable. When a prompt appears: tap "Trust."
 3. Open your device to the homescreen.
 4. Find the extracted `jitterbugpair` file (it should have a black and green icon).
 5. Open Terminal (in Launchpad, it's in the "Utilities" folder).
@@ -47,7 +47,7 @@
    ```bash
    chmod +x ./jitterbugpair
    ```
-4. **Set a passcode** for your device if you haven't already. Unlock your device, connect it to your computer via cable. If a prompt appears: tap "Trust."
+4. **Set a passcode** for your device if you haven't already. Unlock your device and connect it to your computer via cable. When a prompt appears: tap "Trust."
 5. Open your device to the homescreen.
 6. Execute the program:
    ```bash

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -28,7 +28,7 @@ iDevicePair allows us to create a pairing file for programs like StikDebug to ta
 ### Linux
 
 > [!TIP]
-> The iDevicePair instructions for Linux are a work-in-progress. For now, instructions to create a pairing file using JitterbugPair for Linux are below!
+> The iDevicePair instructions for Linux are a work-in-progress, though iDevicePair is pretty intuitive if you want to give it a try instead. For now, instructions to create a pairing file using JitterbugPair for Linux are below!
 
 These instructions expect that you are familiar with the linux commandline.
 

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -21,7 +21,7 @@
 ### For macOS
 
 1. **Extract** `Jitterbugpair-macos.zip` (if applicable).
-2. **Set a passcode** for your device if you haven't already. Unlock your device and connect it to your computer via cable. When a prompt appears: tap "Trust."
+2. **Set a passcode** for your device if you haven't already. Unlock your device and connect it to your computer via cable. When a prompt appears, tap "Trust."
 3. Open your device to the homescreen.
 4. Find the extracted `jitterbugpair` file (it should have a black and green icon).
 5. Open Terminal (in Launchpad, it's in the "Utilities" folder).
@@ -47,7 +47,7 @@
    ```bash
    chmod +x ./jitterbugpair
    ```
-4. **Set a passcode** for your device if you haven't already. Unlock your device and connect it to your computer via cable. When a prompt appears: tap "Trust."
+4. **Set a passcode** for your device if you haven't already. Unlock your device and connect it to your computer via cable. When a prompt appears, tap "Trust."
 5. Open your device to the homescreen.
 6. Execute the program:
    ```bash

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -11,6 +11,8 @@ First, make sure Developer Mode is enabled on your iDevice, then follow the inst
 
 idevice_pair allows us to create a pairing file for programs like StikDebug to talk to your device remotely. This is required to use StikDebug, otherwise it will not function.
 
+---
+
 ### Windows (64-bit)
 
 1. Install [iTunes](https://apple.com/itunes/download/win64) from Apple's website.

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -2,14 +2,11 @@
 
 ### Downloads
 - **Windows**: [iDevicePair--windows-x86_64.exe](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--windows-x86_64.exe)
-- **macOS**: [iDevicePair--macos-universal.dmg](github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--macos-universal.dmg)
-- **Linux**: [jitterbugpair-linux.zip](https://github.com/osy/Jitterbug/releases/download/v1.3.1/jitterbugpair-linux.zip)
-
+- **macOS**: [iDevicePair--macos-universal.dmg](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--macos-universal.dmg)
+- **Linux**: (x86_64: [iDevicePair--linux-x86_64.AppImage](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-x86_64.AppImage), aarch64: [iDevicePair--linux-aarch64.AppImage](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-aarch64.AppImage))
 ---
 
-iDevicePair allows us to create a pairing file for programs like SideStore to talk to your device remotely. This is required to use SideStore, or it will not function.
-
-Download iDevicePair for Linux ([x86_64](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-x86_64.AppImage) or [aarch64](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-aarch64.AppImage)).
+iDevicePair allows us to create a pairing file for programs like StikDebug to talk to your device remotely. This is required to use StikDebug, otherwise it would not function..
 
 ### Windows
 
@@ -18,7 +15,7 @@ Download iDevicePair for Linux ([x86_64](https://github.com/jkcoxson/idevice_pai
 3. Connect your secondary device to your computer via cable. If a prompt appears, tap "trust" and type in your passcode.
 4. Unlock your device, open iDevicePair, and select your device in the drop-down menu.
 5. Ensure your device is unlocked and opened to the home screen, then select "generate". When a prompt appears on your device, tap "trust". Your pairing file should appear.
-6. Ensure your device is still open to the home screen, then scroll down to the SideStore section and select "install". The word "success" should appear in green.
+6. Ensure your device is still open to the home screen, then scroll down to the StikDebug section and select "install". The word "success" should appear in green.
 
 ### macOS
 
@@ -26,7 +23,7 @@ Download iDevicePair for Linux ([x86_64](https://github.com/jkcoxson/idevice_pai
 3. Connect your secondary device to your computer via cable. If a prompt appears, tap "trust" and type in your passcode.
 4. Unlock your device, open iDevicePair, and select your device in the drop-down menu.
 5. Ensure your device is unlocked and opened to the home screen, then select "generate". When a prompt appears on your device, tap "trust". Your pairing file should appear.
-6. Ensure your device is still open to the home screen, then scroll down to the SideStore section and select "install". The word "success" should appear in green.
+6. Ensure your device is still open to the home screen, then scroll down to the StikDebug section and select "install". The word "success" should appear in green.
 
 ### Linux
 

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -9,8 +9,8 @@
 
 ### For Windows
 
-1. **Extract** `Jitterbugpair-win64.zip`.
-2. **Set a passcode** for your device if you haven't already. Unlock your device, connect it to your computer via cable. If a prompt appears: tap "Trust."
+1. **Extract** `jitterbugpair-win64.zip`.
+2. **Set a passcode** for your device if you haven't already. Unlock your device and connect it to your computer via cable. When a prompt appears, tap "Trust."
 3. Open your device to the homescreen.
 4. In File Explorer, locate `jitterbugpair.exe` and run it by double-clicking or right-clicking and selecting "Open".
 5. JitterbugPair will generate a **pairing file** in the same folder. This file will have the extension `.mobiledevicepairing`.
@@ -29,13 +29,12 @@
 7. If you get "macOS cannot verify that this app is free from malware":
    - Go to System Settings > Privacy & Security
    - Scroll down to the message about the app
-   - Click "Open Anyway"
-   - Try running the program again
-8. JitterBugPair will generate a **pairing file** with the extension `.mobiledevicepairing`.
+   - Click "Open Anyway," if the program doesn't run automatically, try manually running it again
+8. JitterbugPair will generate a **pairing file** with the extension `.mobiledevicepairing` to your user's home folder.
 9. If you can't find the pairing file:
    - Copy the name of the pairing file generated
    - Paste it into Finder
-   - If you ran the program more than once all pairing files for your device should appear since they share the same name
+   - If you ran the program more than once, all pairing files for your device should appear since they share the same name
 10. **Transfer the pairing file** to your iOS device using AirDrop, iCloud/One/Google Drive, email, or any other method. For best results, compress the file into a .zip folder first.
 
 ---
@@ -64,7 +63,7 @@
 
 ### On your iOS device
 
-1. In the **Files app**, long-press your zipped pairing file and select **Uncompress**.
+1. In the **Files app**, locate your newly-generated pairing file. (If zipped, long-press your zipped pairing file and select **Uncompress**.)
 2. Launch the **StikDebug** app.
    - If the app doesn't appear, restart your device.
 3. Upon launching the app, tap **Import Pairing File**, then navigate to and select your **unzipped pairing file**.

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -4,11 +4,12 @@
 - **Windows**: [iDevicePair--windows-x86_64.exe](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--windows-x86_64.exe)
 - **macOS**: [iDevicePair--macos-universal.dmg](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--macos-universal.dmg)
 - **Linux**: (x86_64: [iDevicePair--linux-x86_64.AppImage](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-x86_64.AppImage) or AArch64: [iDevicePair--linux-aarch64.AppImage](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-aarch64.AppImage))
+
 ---
 
-idevice_pair allows us to create a pairing file for programs like StikDebug to talk to your device remotely. This is required to use StikDebug, otherwise it will not function.
+First, make sure Developer Mode is enabled on your iDevice, then follow the instructions below.
 
-## Pairing Instructions
+idevice_pair allows us to create a pairing file for programs like StikDebug to talk to your device remotely. This is required to use StikDebug, otherwise it will not function.
 
 ### Windows (64-bit)
 
@@ -18,7 +19,9 @@ idevice_pair allows us to create a pairing file for programs like StikDebug to t
 4. Unlock your device, then, in File Explorer, open `idevice pair` and select your device in the drop-down menu.
 5. Ensure your device is unlocked and opened to the home screen, then select "generate" (If also using an app such as SideStore or Feather which utilizes a pairing file as well, select "load" instead). When a prompt appears on your device, tap "trust". Your pairing file should appear.
 6. Ensure your device is still open to the home screen, then scroll down to the StikDebug section and select "install". The word "success" should appear in green.
-also
+
+---
+
 ### macOS
 
 1. Download `iDevicePair--macos-universal.dmg`. Open the file and drag `idevice pair` to `Applications`.
@@ -26,6 +29,8 @@ also
 3. Unlock your device, then open idevice pair and select your device in the drop-down menu.
 4. Ensure your device is unlocked and opened to the home screen, then select "generate" (If also using an app such as SideStore or Feather which utilizes a pairing file as well, select "load" instead). When a prompt appears on your device, tap "trust". Your pairing file should appear.
 5. Ensure your device is still open to the home screen, then scroll down to the StikDebug section and select "install". The word "success" should appear in green.
+
+---
 
 ### Linux
 

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -3,7 +3,7 @@
 ### Downloads
 - **Windows**: [iDevicePair--windows-x86_64.exe](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--windows-x86_64.exe)
 - **macOS**: [iDevicePair--macos-universal.dmg](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--macos-universal.dmg)
-- **Linux**: (x86_64: [iDevicePair--linux-x86_64.AppImage](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-x86_64.AppImage), aarch64: [iDevicePair--linux-aarch64.AppImage](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-aarch64.AppImage))
+- **Linux**: (x86_64: [iDevicePair--linux-x86_64.AppImage](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-x86_64.AppImage) or AArch64: [iDevicePair--linux-aarch64.AppImage](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-aarch64.AppImage))
 ---
 
 iDevicePair allows us to create a pairing file for programs like StikDebug to talk to your device remotely. This is required to use StikDebug, otherwise it will not function.

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -1,9 +1,9 @@
 ## Pairing Instructions
 
 ### Downloads
-- **Windows**: [Jitterbugpair-win64.zip](https://github.com/osy/Jitterbug/releases/download/v1.3.1/jitterbugpair-win64.zip)
-- **macOS**: [Jitterbugpair-macos.zip](https://github.com/osy/Jitterbug/releases/download/v1.3.1/jitterbugpair-macos.zip)
-- **Linux**: [Jitterbugpair-linux.zip](https://github.com/osy/Jitterbug/releases/download/v1.3.1/jitterbugpair-linux.zip)
+- **Windows**: [jitterbugpair-win64.zip](https://github.com/osy/Jitterbug/releases/download/v1.3.1/jitterbugpair-win64.zip)
+- **macOS**: [jitterbugpair-macos.zip](https://github.com/osy/Jitterbug/releases/download/v1.3.1/jitterbugpair-macos.zip)
+- **Linux**: [jitterbugpair-linux.zip](https://github.com/osy/Jitterbug/releases/download/v1.3.1/jitterbugpair-linux.zip)
 
 ---
 
@@ -41,7 +41,7 @@
 
 ### For Linux
 
-1. **Extract** `Jitterbugpair-linux.zip`.
+1. **Extract** `jitterbugpair-linux.zip`.
 2. Open a terminal in the extracted directory.
 3. Make the program executable:
    ```bash
@@ -53,7 +53,7 @@
    ```bash
    ./jitterbugpair
    ```
-7. JitterBugPair will generate a **pairing file** with the extension `.mobiledevicepairing`.
+7. JitterbugPair will generate a **pairing file** with the extension `.mobiledevicepairing`.
 8. **Transfer the pairing file** to your iOS device using your preferred method. For best results, compress the file into a .zip folder first.
 
 > [!TIP]

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -6,29 +6,29 @@
 - **Linux**: (x86_64: [iDevicePair--linux-x86_64.AppImage](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-x86_64.AppImage) or AArch64: [iDevicePair--linux-aarch64.AppImage](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-aarch64.AppImage))
 ---
 
-iDevicePair allows us to create a pairing file for programs like StikDebug to talk to your device remotely. This is required to use StikDebug, otherwise it will not function.
+iDevice Pair allows us to create a pairing file for programs like StikDebug to talk to your device remotely. This is required to use StikDebug, otherwise it will not function.
 
 ### Windows
 
 1. Install iTunes from Apple's website ([64-bit](https://apple.com/itunes/download/win64) or [32-bit](https://apple.com/itunes/download/win32)).
 2. Download `iDevicePair--windows-x86_64.exe` (move it somewhere you won't lose it).
 3. Connect your secondary device to your computer via cable. If a prompt appears, tap "trust" and type in your passcode.
-4. Unlock your device, open iDevicePair, and select your device in the drop-down menu.
-5. Ensure your device is unlocked and opened to the home screen, then select "generate" (If you are using an app such as SideStore which also utilizes a pairing file, select "load" instead). When a prompt appears on your device, tap "trust". Your pairing file should appear.
+4. Unlock your device, open iDevice Pair, and select your device in the drop-down menu.
+5. Ensure your device is unlocked and opened to the home screen, then select "generate" (If also use an app such as SideStore which utilizes this pairing file, select "load" instead). When a prompt appears on your device, tap "trust". Your pairing file should appear.
 6. Ensure your device is still open to the home screen, then scroll down to the StikDebug section and select "install". The word "success" should appear in green.
 
 ### macOS
 
-1. Download `iDevicePair--macos-universal.dmg`. Open the file and drag "iDevicePair" to your Applications folder.
+1. Download `iDevicePair--macos-universal.dmg`. Open the file and drag `iDevice Pair` to your Applications folder.
 3. Connect your secondary device to your computer via cable. If a prompt appears, tap "trust" and type in your passcode.
-4. Unlock your device, open iDevicePair, and select your device in the drop-down menu.
-5. Ensure your device is unlocked and opened to the home screen, then select "generate" (If you are using an app such as SideStore which also utilizes a pairing file, select "load" instead). When a prompt appears on your device, tap "trust". Your pairing file should appear.
+4. Unlock your device, open iDevice Pair, and select your device in the drop-down menu.
+5. Ensure your device is unlocked and opened to the home screen, then select "generate" (If you also use an app such as SideStore which also utilizes this pairing file, select "load" instead). When a prompt appears on your device, tap "trust". Your pairing file should appear.
 6. Ensure your device is still open to the home screen, then scroll down to the StikDebug section and select "install". The word "success" should appear in green.
 
 ### Linux
 
 > [!TIP]
-> The iDevicePair instructions for Linux are a work-in-progress, though iDevicePair is pretty intuitive if you want to give it a try instead. For now, instructions to create a pairing file using JitterbugPair for Linux are below!
+> The iDevice Pair instructions for Linux are a work-in-progress, though iDevice Pair is pretty intuitive if you want to give it a try without docs first. For now, instructions to create a pairing file using JitterbugPair for Linux are below!
 
 These instructions expect that you are familiar with the linux commandline.
 

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -7,6 +7,10 @@
 
 ---
 
+> [!TIP]
+> When using cloud storage, the file extension might change (usually to .txt). It is always recommended to zip your pairing file before transferring it. StikDebug only accepts `.mobiledevicepairing` or `.plist` files.
+
+
 ### For Windows
 
 1. **Extract** `jitterbugpair-win64.zip`.
@@ -23,19 +27,17 @@
 1. **Extract** `Jitterbugpair-macos.zip` (if applicable).
 2. **Set a passcode** for your device if you haven't already. Unlock your device and connect it to your computer via cable. When a prompt appears, tap "Trust."
 3. Open your device to the homescreen.
-4. Find the extracted `jitterbugpair` file (it should have a black and green icon).
-5. Open Terminal (in Launchpad, it's in the "Utilities" folder).
-6. Drag the `jitterbugpair` file into Terminal and press "Return" or Enter.
-7. If you get "macOS cannot verify that this app is free from malware":
+4. Find and open the extracted `jitterbugpair` file (it should have a black and green icon) by double-clicking it or right-clicking it and selecting "Open."
+5. If you get the message" "macOS cannot verify that this app is free from malware":
    - Go to System Settings > Privacy & Security
    - Scroll down to the message about the app
    - Click "Open Anyway," if the program doesn't run automatically, try manually running it again
-8. JitterbugPair will generate a **pairing file** with the extension `.mobiledevicepairing` to your user's home folder.
-9. If you can't find the pairing file:
+7. JitterbugPair will generate a **pairing file** with the extension `.mobiledevicepairing` to your user's home folder.
+8. If you can't find the pairing file:
    - Copy the name of the pairing file generated
    - Paste it into Finder
    - If you ran the program more than once, all pairing files for your device should appear since they share the same name
-10. **Transfer the pairing file** to your iOS device using AirDrop, iCloud/One/Google Drive, email, or any other method. For best results, compress the file into a .zip folder first.
+9. **Transfer the pairing file** to your iOS device using AirDrop, iCloud/One/Google Drive, email, or any other method. For best results, compress the file into a .zip folder first.
 
 ---
 
@@ -55,9 +57,6 @@
    ```
 7. JitterbugPair will generate a **pairing file** with the extension `.mobiledevicepairing`.
 8. **Transfer the pairing file** to your iOS device using your preferred method. For best results, compress the file into a .zip folder first.
-
-> [!TIP]
-> When using cloud storage, the file extension might change (usually to .txt). It is always recommended to zip your pairing file before transferring it. StikDebug only accepts `.mobiledevicepairing` or `.plist` files.
 
 ---
 

--- a/pairing_file.md
+++ b/pairing_file.md
@@ -6,7 +6,7 @@
 - **Linux**: (x86_64: [iDevicePair--linux-x86_64.AppImage](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-x86_64.AppImage) or AArch64: [iDevicePair--linux-aarch64.AppImage](https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-aarch64.AppImage))
 ---
 
-idevice pair allows us to create a pairing file for programs like StikDebug to talk to your device remotely. This is required to use StikDebug, otherwise it will not function.
+idevice_pair allows us to create a pairing file for programs like StikDebug to talk to your device remotely. This is required to use StikDebug, otherwise it will not function.
 
 ## Pairing Instructions
 


### PR DESCRIPTION
Updates StikDebug docs to match the old but more updated StikJIT docs a little closer, updates some wording and fixes some grammatical and capitalization errors.
EDIT: Now updates to iDevice Pair instructions for Windows and macOS. Linux coming later.